### PR TITLE
[codex] Fix HOST and PORT environment handling

### DIFF
--- a/server/__init__.py
+++ b/server/__init__.py
@@ -24,7 +24,7 @@ import os
 from .api import app as _api
 
 
-def app(host="127.0.0.1", port=8000) -> None:
+def app(host=None, port=None) -> None:
     """Start the server (blocks while uvicorn runs).
 
     On first run (no saved session) this opens a browser for interactive sign-in
@@ -34,8 +34,10 @@ def app(host="127.0.0.1", port=8000) -> None:
 
     from copilot.auth import load_auth
 
-    host = host or os.environ.get("HOST", "127.0.0.1")
-    port = port or int(os.environ.get("PORT", "8000"))
+    if host is None:
+        host = os.environ.get("HOST", "127.0.0.1")
+    if port is None:
+        port = int(os.environ.get("PORT", "8000"))
 
     # Ensure a signed-in Copilot session exists before we start serving. On the
     # very first run this triggers the interactive browser sign-in (instead of

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,40 @@
+"""Tests for server startup configuration."""
+
+import os
+import unittest
+from unittest.mock import patch
+
+from server import app
+
+
+class ServerStartupTests(unittest.TestCase):
+    @patch("uvicorn.run")
+    @patch("copilot.auth.load_auth")
+    def test_uses_default_address(self, _load_auth, run):
+        with patch.dict(os.environ, {}, clear=True):
+            app()
+
+        self.assertEqual(run.call_args.kwargs["host"], "127.0.0.1")
+        self.assertEqual(run.call_args.kwargs["port"], 8000)
+
+    @patch("uvicorn.run")
+    @patch("copilot.auth.load_auth")
+    def test_uses_address_from_environment(self, _load_auth, run):
+        with patch.dict(os.environ, {"HOST": "0.0.0.0", "PORT": "8080"}, clear=True):
+            app()
+
+        self.assertEqual(run.call_args.kwargs["host"], "0.0.0.0")
+        self.assertEqual(run.call_args.kwargs["port"], 8080)
+
+    @patch("uvicorn.run")
+    @patch("copilot.auth.load_auth")
+    def test_explicit_address_takes_precedence(self, _load_auth, run):
+        with patch.dict(os.environ, {"HOST": "0.0.0.0", "PORT": "8080"}, clear=True):
+            app(host="localhost", port=0)
+
+        self.assertEqual(run.call_args.kwargs["host"], "localhost")
+        self.assertEqual(run.call_args.kwargs["port"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes the server launcher so the documented `HOST` and `PORT` environment variables are honored when running `python app.py`.

## Root cause

The `app` function had populated default arguments, so its environment-variable fallback was never reached. The updated implementation resolves defaults only when the corresponding argument is `None`.

## Behavior

- Defaults remain `127.0.0.1:8000`
- `HOST` and `PORT` environment variables are honored
- Explicit `app(host=..., port=...)` arguments take precedence
- An explicit port of `0` is preserved

## Tests

- `python -m unittest discover -s tests -p test_*.py -v`
- `git diff --check`